### PR TITLE
Accurately target and remove indenting when editing settings.xml 

### DIFF
--- a/bcml/install.py
+++ b/bcml/install.py
@@ -193,9 +193,9 @@ def main(args):
         setpath = os.path.join(args.directory, '../', 'settings.xml')
         setread = ''
         with open(setpath, 'r') as setfile:
-            for line in setfile.readlines():
-                setread += line
-        settings = minidom.parseString(setread.replace('\n','').replace('\r','').rstrip('\r\n').replace('  ',''))
+            for line in setfile:
+                setread += line.strip()
+        settings = minidom.parseString(setread)
         gpack = settings.getElementsByTagName('GraphicPack')[0]
         hasbcml = False
         for entry in gpack.getElementsByTagName('Entry'):
@@ -218,7 +218,7 @@ def main(args):
         modentry.appendChild(entryfile)
         modentry.appendChild(entrypreset)
         gpack.appendChild(modentry)
-        settings.writexml(open(setpath, 'w'),indent='',addindent='    ',newl='\n')
+        settings.writexml(open(setpath, 'w'),addindent='    ',newl='\n')
 
         if args.leave: open(os.path.join(moddir,'.leave'), 'w').close()
         if args.shrink: open(os.path.join(moddir,'.shrink'), 'w').close()


### PR DESCRIPTION
- remove readlines() as it introduces unwanted trailing newlines
- use strip() instead of replace() to avoid targeting whitespace characters that aren't indenting
- remove redundant indent parameter from writexml()