### PR TITLE
pynsist support

### DIFF
--- a/bcml/__init__.py
+++ b/bcml/__init__.py
@@ -68,7 +68,7 @@ def main():
 
     print('##############################################')
     print('##    Breath of the Wild Cemu Mod Loader    ##')
-    print('##              Version 1.22                ##')
+    print('##              Version 1.25                ##')
     print('##------------------------------------------##')
     print('##     (c) 2019 Nicene Nerd - GPLv3+        ##')
     print('##  7z.exe (c) 2019 Ignor Pavolv - LGPLv3+  ##')

--- a/bcml/gui.py
+++ b/bcml/gui.py
@@ -76,7 +76,7 @@ class BcmlFrame(wx.Frame):
 
     def __set_properties(self):
         # begin wxGlade: BcmlFrame.__set_properties
-        self.SetTitle("BCML: BotW Cemu Mod Loader")
+        self.SetTitle("BCML: BotW Cemu Mod Loader - v1.25")
         self.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWFRAME))
         self.SetPosition((64, 32))
         self.SetMaxClientSize((512,-1))

--- a/installer.cfg
+++ b/installer.cfg
@@ -1,0 +1,26 @@
+[Application]
+name=bcml
+version=1.25
+# How to launch the app - this calls the 'main' function from the 'myapp' package:
+entry_point=bcml.gui:main
+icon=bcml/data/bcml.ico
+
+[Command bcml]
+entry_point=bcml.__init__:main
+
+[Python]
+version=3.7.3
+
+[Include]
+# Packages from PyPI that your application requires, one per line
+# These must have wheels on PyPI:
+pypi_wheels = pyYaml==5.1.1
+     sarc==2.0.1
+     rstb==1.1.2
+     wszst_yaz0==1.2.0
+     wxPython==4.0.6
+     xxhash==1.3.0
+
+# Other files and folders that should be installed
+files = docs/
+    bcml/

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("docs/README.md", "r") as readme:
 
 setup(
     name='bcml',
-    version='1.22',
+    version='1.25',
     author='NiceneNerd',
     author_email='macadamiadaze@gmail.com',
     description='A mod manager for The Legend of Zelda: Breath of the Wild on Cemu',


### PR DESCRIPTION
Added `installer.cfg` to build a Windows executable installer that doesn't require Python in advance using `pynsist`