### PR TITLE
More shop merger fixes

### DIFF
--- a/bcml/mergers/shop.py
+++ b/bcml/mergers/shop.py
@@ -164,6 +164,7 @@ def get_shop_diff(pio: ParameterIO, ref_pio: ParameterIO) -> ParameterList:
 def merge_shopdata(pio: ParameterIO, plist: ParameterList):
     def make_bshop(plist: ParameterList) -> ParameterIO:
         bshop = ParameterIO()
+        bshop.type = "xml"
         tables: List[str] = [str(t.v) for _, t in plist.objects["TableNames"].params.items()]
         bshop.objects["Header"] = ParameterObject()
         bshop.objects["Header"].params["TableNum"] = Parameter(len(tables))

--- a/bcml/mergers/shop.py
+++ b/bcml/mergers/shop.py
@@ -97,9 +97,12 @@ def make_shopdata(pio: ParameterIO) -> ParameterList:
             )
             item_obj = ParameterObject()
             for shop_key in shop_keys:
-                item_obj.params[shop_key] = pio.objects[table_hash].params[
-                    f"{shop_key}{item_no:03d}"
-                ]
+                try:
+                    item_obj.params[shop_key] = pio.objects[table_hash].params[
+                        f"{shop_key}{item_no:03d}"
+                    ]
+                except KeyError:
+                    raise KeyError(f"{shop_key}{item_no:03d}")
             table_plist.objects[item] = item_obj
         if table_plist.objects:
             shopdata.lists[table_hash] = table_plist

--- a/bcml/mergers/shop.py
+++ b/bcml/mergers/shop.py
@@ -184,10 +184,6 @@ def merge_shopdata(pio: ParameterIO, plist: ParameterList):
         return bshop
 
     shopdata = make_shopdata(pio)
-
-    # For backwards compatibility with new bnp's made since the rewrite
-    subtract_plists(plist.lists["Removals"], plist.lists["Additions"])
-
     subtract_plists(shopdata, plist.lists["Removals"])
     merge_plists(shopdata, plist.lists["Additions"])
     return make_bshop(shopdata)


### PR DESCRIPTION
Fixes KeyErrors on merge when there are modified item parameters (as opposed to whole item additions or removals)
Raises correct KeyErrors when there are missing keys for an item during diff time
Sets proper ParameterIO type (unknown how important this actually is, but no harm in it)