### PR TITLE
Prevent priority bump on update

### DIFF
--- a/bcml/_api.py
+++ b/bcml/_api.py
@@ -356,6 +356,7 @@ class Api:
                 insert_priority=mod.priority,
                 options=options,
                 pool=pool,
+                updated=True,
             )
 
     @win_or_lose

--- a/bcml/install.py
+++ b/bcml/install.py
@@ -482,7 +482,7 @@ def install_mod(
     mod_dir = util.get_modpack_dir() / mod_id
 
     try:
-        if (updated == False):
+        if not updated:
             for existing_mod in util.get_installed_mods(True):
                 if existing_mod.priority >= priority:
                     existing_mod.change_priority(existing_mod.priority + 1)

--- a/bcml/install.py
+++ b/bcml/install.py
@@ -331,6 +331,7 @@ def install_mod(
     pool: Optional[multiprocessing.pool.Pool] = None,
     insert_priority: int = 0,
     merge_now: bool = False,
+    updated: bool = False,
 ):
     if not insert_priority:
         insert_priority = get_next_priority()
@@ -481,9 +482,10 @@ def install_mod(
     mod_dir = util.get_modpack_dir() / mod_id
 
     try:
-        for existing_mod in util.get_installed_mods(True):
-            if existing_mod.priority >= priority:
-                existing_mod.change_priority(existing_mod.priority + 1)
+        if (updated == False):
+            for existing_mod in util.get_installed_mods(True):
+                if existing_mod.priority >= priority:
+                    existing_mod.change_priority(existing_mod.priority + 1)
 
         mod_dir.parent.mkdir(parents=True, exist_ok=True)
         print(f"Moving mod to {str(mod_dir)}...")


### PR DESCRIPTION
Skips the bump in mod priority on already installed mods when updating a mod avoiding large gaps in the load order.