### PR TITLE
Update to v7, enable by defualt

### DIFF
--- a/bcml/util.py
+++ b/bcml/util.py
@@ -1196,7 +1196,8 @@ def create_bcml_graphicpack_if_needed():
             "name = BCML\n"
             "path = The Legend of Zelda: Breath of the Wild/Mods/BCML\n"
             "description = Complete pack of mods merged using BCML\n"
-            "version = 4\n"
+            "version = 7\n"
+            "default = true\n"
             "fsPriority = 9999",
             encoding="utf-8",
         )


### PR DESCRIPTION
Update the BCML graphics pack to use v7 features, and enable it by default.
BCML is *supposed* to be able to enable the pack when launching, but it barely ever works on my system. This has Cemu enable it by default, which is far more reliable.
(This is mainly to make first-time setup go smoother, I've seen many people get hung up because they didn't realize they had to enable the pack)