### PR TITLE
feat(ui): clarify game languages hydration tooltip

### DIFF
--- a/bcml/assets/src/js/Settings.jsx
+++ b/bcml/assets/src/js/Settings.jsx
@@ -373,6 +373,8 @@ class Settings extends React.Component {
                                     <Tooltip>
                                         The game language you play with. This will be
                                         prioritized when attempting to merge text mods.
+                                        You must load game files before this dropdown
+                                        populates.
                                     </Tooltip>
                                 }>
                                 <Form.Control


### PR DESCRIPTION
# problem

most tutorials in the wild target cemu. as a wii u user, i was surprised that i needed a game dump to use bcml, and was confused for a bit on why i could not fill set a target lang.

# solution

clarify that lang populates only once game files are set. probably worth asserting somewhere that console use requires a dump as well _somewhere_, but that's for another docs segment!