### PR TITLE
aslist.py: Fix cast

### DIFF
--- a/bcml/mergers/aslist.py
+++ b/bcml/mergers/aslist.py
@@ -104,12 +104,12 @@ def get_aamp_diff(pio: ParameterIO, ref_pio: ParameterIO) -> ParameterList:
         diff = ParameterList()
         defs: Dict[str, str] = {}
         for _, pobj in asdef.objects.items():
-            defs[str(pobj.params["Name"].v)] = pobj.params["Filename"].v
+            defs[str(pobj.params["Name"].v)] = str(pobj.params["Filename"].v)
         for _, ref_pobj in ref_asdef.objects.items():
             try:
                 if (
                     defs[str(ref_pobj.params["Name"].v)]
-                    == ref_pobj.params["Filename"].v
+                    == str(ref_pobj.params["Filename"].v)
                 ):
                     defs.pop(str(ref_pobj.params["Name"].v))
             except (ValueError, KeyError):


### PR DESCRIPTION
-Cast Filename value to string, so that contents are compared instead of pointers
-Fixes attempt to wrap an FSS64 in another FSS64 in `for i, (k, v)…`

This was done on my phone, and so could not be tested locally- should be tested before merge (can do so, myself, after Dec 6th)