### PR TITLE
Add `--portable` flag

### DIFF
--- a/bcml/__main__.py
+++ b/bcml/__main__.py
@@ -57,6 +57,7 @@ def configure_cef(debug):
 
 
 def main(debug: bool = False):
+    util.parse_arguments()
     set_start_method("spawn", True)
     global logger  # pylint: disable=invalid-name,global-statement
     logger = None

--- a/bcml/util.py
+++ b/bcml/util.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring,no-member,too-many-lines,invalid-name
 # Copyright 2020 Nicene Nerd <macadamiadaze@gmail.com>
 # Licensed under GPLv3+
+import argparse
 import functools
 import gc
 import json
@@ -519,9 +520,30 @@ def get_python_exe(gui: bool) -> Path:
             return sys.executable
 
 
+command_args: argparse.Namespace
+
+
+@lru_cache(1)
+def parse_arguments() -> argparse.Namespace:
+    global command_args
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--portable", help="Runs BCML in portable mode preferring to store the working directory locally.", action="store_true")
+    command_args = parser.parse_args()
+    return command_args
+
+
+@lru_cache(1)
+def get_is_portable_mode() -> bool:
+    args = parse_arguments()
+    return args.portable == True
+
+
 @lru_cache(None)
 def get_data_dir() -> Path:
-    if system() == "Windows":
+    if get_is_portable_mode():
+        data_dir = Path(os.getcwd()) / "bcml-data"
+    elif system() == "Windows":
         data_dir = Path(os.path.expandvars("%LOCALAPPDATA%")) / "bcml"
     else:
         data_dir = Path.home() / ".config" / "bcml"

--- a/bcml/util.py
+++ b/bcml/util.py
@@ -528,7 +528,10 @@ def parse_arguments() -> argparse.Namespace:
     global command_args
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--portable", help="Runs BCML in portable mode preferring to store the working directory locally.", action="store_true")
+        "--portable",
+        help="Runs BCML in portable mode preferring to store the working directory locally.",
+        action="store_true",
+    )
     command_args = parser.parse_args()
     return command_args
 
@@ -1465,7 +1468,9 @@ def get_7z_path():
     bundle_path = get_exec_dir() / "helpers" / "7z"
     if not os.access(bundle_path, os.X_OK):
         if not os.access(bundle_path, os.W_OK):
-            raise PermissionError(f"{bundle_path} is not executable and we don't have the permissions to change that")
+            raise PermissionError(
+                f"{bundle_path} is not executable and we don't have the permissions to change that"
+            )
         os.chmod(bundle_path, 0o755)
     if get_settings("force_7z"):
         return str(bundle_path)


### PR DESCRIPTION
I know you mentioned in #161 that you weren't interested in adding a CLI in the immediate term, but there was a feature I was looking for that more or less called for some sort of command line argument, as it couldn't be something done via the configuration file: and that's where the configuration file comes from!

This PR adds the ability to run BCML with the flag `--portable` (Works via both `bcml --portable` and `python -m bcml --portable` in my testing.) If the flag is present, BCML will use `<current working directory>\bcml-data` as it's `data_dir`, rather than the platform specific user data folders (`%LOCALAPPDATA%\bcml`/`~/.config/bcml`.)

This feature allows users to keep BCML on a removable disk, and transport it between machines, keeping its configuration and working directories with it.