### PR TITLE
drop.py: cast ints to int in case they're unsigned

### DIFF
--- a/bcml/mergers/drop.py
+++ b/bcml/mergers/drop.py
@@ -13,12 +13,14 @@ from bcml import mergers, util
 def _drop_to_dict(drop: ParameterIO) -> dict:
     return {
         str(table.v): {
-            "repeat_num_min": drop.objects[str(table.v)].params["RepeatNumMin"].v,
-            "repeat_num_max": drop.objects[str(table.v)].params["RepeatNumMax"].v,
-            "approach_type": drop.objects[str(table.v)].params["ApproachType"].v,
-            "occurrence_speed_type": drop.objects[str(table.v)]
-            .params["OccurrenceSpeedType"]
-            .v,
+            "repeat_num_min": int(drop.objects[str(table.v)].params["RepeatNumMin"].v),
+            "repeat_num_max": int(drop.objects[str(table.v)].params["RepeatNumMax"].v),
+            "approach_type": int(drop.objects[str(table.v)].params["ApproachType"].v),
+            "occurrence_speed_type": int(
+                drop.objects[str(table.v)]
+                .params["OccurrenceSpeedType"]
+                .v
+            ),
             "items": {
                 str(
                     drop.objects[str(table.v)].params[f"ItemName{i:02}"].v


### PR DESCRIPTION
Note: This PR is a fix for mod author errors, not BCML errors, so it may be unwanted behavior. Feel free to deny it.

Some mod authors apparently decided it would be fun to replace every signed int in their drop files with unsigned ints. This will cast any Parameter values that *should* be int, to int. Should fix any `Object of type [type] is not JSON serializable` errors.