### PR TITLE
Remove `.sblwp` from `NO_CONVERT_EXTS`

### DIFF
--- a/bcml/dev.py
+++ b/bcml/dev.py
@@ -473,7 +473,6 @@ NO_CONVERT_EXTS = {
     ".sbreviewtex",
     ".sbitemico",
     ".sstats",
-    ".sblwp",
     ".sbstftex",
     ".sblarc",
     ".bfsar",


### PR DESCRIPTION
".sblwp" files are the same on both platforms, so no conversion is needed