### PR TITLE
Add camera animation files to `NO_CONVERT_EXTS`

### DIFF
--- a/bcml/dev.py
+++ b/bcml/dev.py
@@ -462,6 +462,8 @@ def create_bnp_mod(mod: Path, output: Path, meta: dict, options: Optional[dict] 
 NO_CONVERT_EXTS = {
     ".sbfres",
     ".bfres",
+    ".bcamanim",
+    ".sbcamanim",
     ".hkcl",
     ".hkrg",
     ".sesetlist",


### PR DESCRIPTION
Camera animation (a.k.a .bcamanim) files are just bfres files, which aren't supported