### PR TITLE
Fixes game-breaking bugs for mods with custom AISchedule

### DIFF
--- a/bcml/mergers/rstable.py
+++ b/bcml/mergers/rstable.py
@@ -58,7 +58,7 @@ def calculate_size(
             data, wiiu=be, ext=ext, force=False
         )
         if ext == ".baischedule":
-            size = 100
+            size += 100
         if ext == ".bdmgparam":
             size = 0
         if ext == ".hkrb":


### PR DESCRIPTION
The estimates bytes for custom AISchedules is sometimes too low. Since @leoetlino hasn't responded to the issue (https://github.com/zeldamods/rstb/issues/5) yet for rstb tool, I recommend to merge my +100 bytes fix for now. People are complaining that they cannot play the game when they install with BCML. This change fixes it.