### PR TITLE
Remove argument parser call in main.

### DIFF
--- a/bcml/__main__.py
+++ b/bcml/__main__.py
@@ -57,7 +57,6 @@ def configure_cef(debug):
 
 
 def main(debug: bool = False):
-    util.parse_arguments()
     set_start_method("spawn", True)
     global logger  # pylint: disable=invalid-name,global-statement
     logger = None


### PR DESCRIPTION
Removes util.parse_arguments in __main__.py which was causing an error on startup:
```
Traceback (most recent call last):
  File "C:\Python\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Python\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Python\lib\site-packages\bcml\__main__.py", line 163, in <module>
    main()
  File "C:\Python\lib\site-packages\bcml\__main__.py", line 60, in main
    util.parse_arguments()
AttributeError: module 'bcml.util' has no attribute 'parse_arguments'
```