### PR TITLE
Remove random invalid decorator

### DIFF
--- a/bcml/__version__.py
+++ b/bcml/__version__.py
@@ -1,7 +1,7 @@
 _MAJOR=3
 _MINOR=8
 _PATCH="3"
-@id:vxna.one-dark-nx
+
 VERSION = f"{_MAJOR}.{_MINOR}.{_PATCH}"
 USER_VERSION = f"""{_MAJOR}.{_MINOR}.{_PATCH[0:1]} {
     'alpha' if _MAJOR < 1 else ''


### PR DESCRIPTION
Removes a weird decorator in the `__version__.py` file on line 4.

```py
_MAJOR=3
_MINOR=8
_PATCH="3"
@id:vxna.one-dark-nx # removed line
VERSION = f"{_MAJOR}.{_MINOR}.{_PATCH}"
USER_VERSION = f"""{_MAJOR}.{_MINOR}.{_PATCH[0:1]} {
    'alpha' if _MAJOR < 1 else ''
}{
    f'beta {_PATCH[_PATCH.rindex("b") + 1:]}' if 'b' in _PATCH else ''
}{
    f'release candidate {_PATCH[_PATCH.rindex("rc") + 2:]}' if 'rc' in _PATCH else ''
}"""
```