### PR TITLE
Fix #318, #320

### DIFF
--- a/bcml/mergers/quests.py
+++ b/bcml/mergers/quests.py
@@ -163,8 +163,10 @@ class QuestMerger(mergers.Merger):
                 try:
                     quest_index = 0 if add["prev_quest"] == "--index_zero" else quests.index(add["prev_quest"]) + 1
                     del add["prev_quest"]
-                except (KeyError, IndexError):
+                except KeyError:
                     pass
+                except IndexError:
+                    del add["prev_quest"]
                 quests.insert(quest_index, add)
                 added_names.add(add["Name"])
 

--- a/bcml/mergers/quests.py
+++ b/bcml/mergers/quests.py
@@ -162,9 +162,9 @@ class QuestMerger(mergers.Merger):
                 quest_index = len(quests)
                 try:
                     quest_index = 0 if add["prev_quest"] == "--index_zero" else quests.index(add["prev_quest"]) + 1
+                    del add["prev_quest"]
                 except (KeyError, IndexError):
                     pass
-                dict(add).pop("prev_quest", None)
                 quests.insert(quest_index, add)
                 added_names.add(add["Name"])
 


### PR DESCRIPTION
`dict()` cast creates a deepcopy of the oead.byml.Hash, which means making the change to the casted dict but then using the Hash later just neuters that code line.

The key only needs to be removed if line 164 doesn't throw a KeyError, so it can be included in the same try block as 164. (This means there has to be separate except blocks for KeyError and IndexError, which I feel is messy, but the code itself doesn't care at runtime, at least)

EDIT: Including closing links:
Closes #318 
Closes #320 