### PR TITLE
Symlinks, minor tweaks

### DIFF
--- a/bcml/__main__.py
+++ b/bcml/__main__.py
@@ -1,3 +1,4 @@
+import ctypes
 import os
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -56,7 +57,22 @@ def configure_cef(debug):
         cache.mkdir(parents=True, exist_ok=True)
 
 
+def is_admin():
+    try:
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    except:
+        return False
+
+
 def main(debug: bool = False):
+    if SYSTEM == "Windows" and not is_admin():
+        args = []
+        if Path(sys.executable).stem == "python":
+            args.append("-m")
+            args.append("bcml")
+        args += sys.argv[1:]
+        ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, ' '.join(args), None, 1)
+        exit(0)
     set_start_method("spawn", True)
     global logger  # pylint: disable=invalid-name,global-statement
     logger = None

--- a/bcml/dev.py
+++ b/bcml/dev.py
@@ -491,7 +491,9 @@ def _convert_actorpack(actor_pack: Path, to_wiiu: bool) -> Union[None, str]:
     new_sarc = oead.SarcWriter.from_sarc(sarc)
     new_sarc.set_endianness(oead.Endianness.Big if to_wiiu else oead.Endianness.Little)
     for file in sarc.get_files():
-        if "Physics/" in file.name and "Actor/" not in file.name:
+        if file.data[0:2] == b"BY" or file.data[0:2] == b"YB":
+            new_sarc.files[file.name] = oead.byml.to_binary(oead.byml.from_binary(file.data), to_wiiu)
+        elif "Physics/" in file.name and "Actor/" not in file.name:
             ext = file.name[file.name.rindex(".") :]
             if ext in NO_CONVERT_EXTS:
                 if not util.is_file_modded(

--- a/bcml/install.py
+++ b/bcml/install.py
@@ -850,7 +850,7 @@ def link_master_mod(output: Path = None):
         reverse=True,
     )
     util.vprint(mod_folders)
-    link_or_copy: Any = os.link if not util.get_settings("no_hardlinks") else copyfile
+    link_or_copy: Any = os.symlink if not util.get_settings("no_hardlinks") else copyfile
     for mod_folder in mod_folders:
         for item in mod_folder.rglob("**/*"):
             rel_path = item.relative_to(mod_folder)
@@ -868,14 +868,7 @@ def link_master_mod(output: Path = None):
             if item.is_dir():
                 (output / rel_path).mkdir(parents=True, exist_ok=True)
             elif item.is_file():
-                try:
-                    link_or_copy(str(item), str(output / rel_path))
-                except OSError:
-                    if link_or_copy is os.link:
-                        link_or_copy = copyfile
-                        link_or_copy(str(item), str(output / rel_path))
-                    else:
-                        raise
+                link_or_copy(str(item), str(output / rel_path))
     if not any(output.iterdir()):
         raise RuntimeError(
             "No files were created in your export directory. This may mean BCML"

--- a/bcml/install.py
+++ b/bcml/install.py
@@ -876,7 +876,7 @@ def link_master_mod(output: Path = None):
                         link_or_copy(str(item), str(output / rel_path))
                     else:
                         raise
-    if len(list(output.rglob("*"))) == 0:
+    if not any(output.iterdir()):
         raise RuntimeError(
             "No files were created in your export directory. This may mean BCML"
             " lacked then necessary permissions to write to the folder, or "

--- a/bcml/mergers/texts.py
+++ b/bcml/mergers/texts.py
@@ -190,7 +190,10 @@ def diff_msyt(msyt: Path, hashes: dict, mod_out: Path, ref_dir: Path):
             ref_text = (ref_dir / filename).read_text("utf-8")
             if "".join(text.split()) != "".join(ref_text.split()):
                 ref_contents = json.loads(ref_text)
-                contents = json.loads(text)
+                try:
+                    contents = json.loads(text)
+                except json.decoder.JSONDecodeError as e:
+                    raise RuntimeError(f"{filename} could not be converted for merging: {e}")
                 diff[filename] = {
                     entry: value
                     for entry, value in contents["entries"].items()


### PR DESCRIPTION
Needs testing on Linux to see if the symlink thing works

Downsides: Prompts user for admin perms every time bcml is run

* Changes hard links to symlinks (speeds up cemu export when exporting across drives/partitions/volumes)
* Switch <-> WiiU converter converts BYML files in actor packs
* Speeds up the check to see if the final merge export has any files in it
* ~~Better error reporting for msbt json errors~~ Removed, unnecessary with the new rust converter