### PR TITLE
Cast WindowsPath to str for Rust extension

### DIFF
--- a/bcml/install.py
+++ b/bcml/install.py
@@ -739,7 +739,7 @@ def disable_bcml_gfx():
 
 def link_master_mod(output: Path = None):
     util.create_bcml_graphicpack_if_needed()
-    rsext.manager.link_master_mod(output)
+    rsext.manager.link_master_mod(str(output.absolute()))
     # if not output:
     #     if not util.get_settings(
     #         "export_dir" if util.get_settings("wiiu") else "export_dir_nx"


### PR DESCRIPTION
Got an error when exporting some mods saying that `WindowsPath couldn't be cast to a StringPy` (or similar, can't recall specifics). Anyhow, casting the path to a string seems to have fixed it. I also added `absolute()` just to be safe.