### PR TITLE
BFRES RSTB Crash Fix - Custom Number Shrines aoc

### DIFF
--- a/bcml/mergers/rstable.py
+++ b/bcml/mergers/rstable.py
@@ -57,6 +57,8 @@ def calculate_size(
         size = getattr(calculate_size, "calculator").calculate_file_size_with_ext(
             data, wiiu=be, ext=ext, force=False
         )
+        if ext == ".bfres":
+            size += 1000
         if ext == ".baischedule":
             size += 100
         if ext == ".bdmgparam":


### PR DESCRIPTION
With this fix, you can load into a custom number shrine in aoc directory without a crash.