### PR TITLE
Missing language merge fix

### DIFF
--- a/src/mergers/texts.rs
+++ b/src/mergers/texts.rs
@@ -25,6 +25,7 @@ pub fn diff_language(
     py: Python,
     mod_bootup_path: String,
     stock_bootup_path: String,
+    only_new_keys: bool,
 ) -> PyResult<PyObject> {
     let diff = py.allow_threads(|| -> Result<IndexMap<String, Diff>> {
         let language = &Path::new(&mod_bootup_path)
@@ -69,8 +70,13 @@ pub fn diff_language(
                                 .entries
                                 .iter()
                                 .filter(|(e, t)| {
-                                    !stock_text.entries.contains_key(*e)
-                                        || *t != stock_text.entries.get(*e).unwrap()
+                                    if only_new_keys {
+                                        !stock_text.entries.contains_key(*e)
+                                    }
+                                    else {
+                                        !stock_text.entries.contains_key(*e)
+                                            || *t != stock_text.entries.get(*e).unwrap()
+                                    }
                                 })
                                 .map(|(e, t)| (e.to_owned(), t.clone()))
                                 .collect();


### PR DESCRIPTION
Makes some drastic changes to the language diff mapping:
- If the user has the mod language, use the mod language
- If the user doesn't have the mod language:
  - If the user has the same language from a different locale, use that language
  - If the user has a different language from the same locale, use that language
  - Use whatever language the mod has

This means that the rust differ would apply every value from the mod language, including non-modded values, to the mapped user language (essentially replacing the entire file) so, to solve this, a third arg was added to the rust function, `only_new_keys`, which only changes the text for completely new keys if the mod language doesn't match the user language.

This means that any modified vanilla text doesn't get copied over, but if they don't share a language with the mod, then I don't see another way around this while still allowing them to install the mod, without going back to the pre-rust method of including the entirety of the vanilla text as a resource.

As it currently stands, they simply *can't* install a graphic pack mod if the mod doesn't share a language with them. Since some mods don't offer bnp's, that means the language barrier stops them from using the mod completely.

I personally think this is a better solution, but am open to discussion on the topic.