### PR TITLE
Merge texts from english before merging from random language

### DIFF
--- a/bcml/assets/src/js/Settings.jsx
+++ b/bcml/assets/src/js/Settings.jsx
@@ -375,6 +375,9 @@ class Settings extends React.Component {
                                     <Tooltip>
                                         The game language you play with. This will be
                                         prioritized when attempting to merge text mods.
+                                        You must correctly fill out the base game and
+                                        update path settings, above, before this dropdown
+                                        populates.
                                     </Tooltip>
                                 }>
                                 <Form.Control

--- a/bcml/mergers/texts.py
+++ b/bcml/mergers/texts.py
@@ -62,8 +62,8 @@ def map_languages(src_langs: Set[str], dest_langs: Set[str]) -> dict:
             if src_lang in lang_map:
                 continue
             for dest_lang in dest_langs:
-                if src_lang[0:2] == dest_lang[0:2]:
-                    lang_map[src_lang] = dest_lang # map whatever language from same locale
+                if dest_lang[2:4] == "en":
+                    lang_map[src_lang] = dest_lang # map to english, as most users know english
                     break
             if src_lang in lang_map:
                 continue


### PR DESCRIPTION
Not really a fan of the english elitism implied by this one (despite being EFL, myself) but as someone pointed out, english is the most commonly-spoken language in the world (not including macrolanguages like chinese and indian)

Also implements the changes put forward in PR 207 (linked later) as that seems to have been abandoned. It's unrelated, but is such a tiny change that I figure tossing it in here is fine.

Closes #207 