### PR TITLE
Two fixes

### DIFF
--- a/bcml/mergers/rstable.py
+++ b/bcml/mergers/rstable.py
@@ -74,7 +74,7 @@ def calculate_size(
         if size == 0 and guess:
             if ext in util.AAMP_EXTS:
                 size = guess_aamp_size(data, be, ext)
-            elif ext in {".bfres", ".sbfres"} and len(data) < 5_000_000:
+            elif ext in {".bfres", ".sbfres"}:
                 size = guess_bfres_size(
                     data,
                     be,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -122,8 +122,9 @@ fn link_master_mod(py: Python, output: Option<String>) -> PyResult<()> {
             #[cfg(target_os = "linux")]
             remove_dir_all(&output).context("Failed to clear out output folder")?;
             #[cfg(target_os = "windows")]
-            if !junction::exists(&output).unwrap() {
-                remove_dir_all(&output).context("Failed to clear out output folder")?;
+            match junction::exists(&output) {
+                Ok(b) => if !b { std::fs::remove_dir(&output).context("Failed to clear out output folder")? },
+                Err(_e) => remove_dir_all(&output).context("Failed to clear out output folder")?,
             }
         }
         if !output.exists() {


### PR DESCRIPTION
Handles the windows case of `junction::exists()` throwing an error (which it does when the directory exists as a regular folder)
Reverts rstable.py to make it handle 5MB+ bfres's again. (Fixes Second Wind resources allocating too much memory)