### PR TITLE
Added support for Linux Cemu (Cemu 2.0+ only)

### DIFF
--- a/bcml/_api.py
+++ b/bcml/_api.py
@@ -103,7 +103,7 @@ class Api:
         if not real_folder:
             return False
         if params["type"] == "cemu_dir":
-            return len(list(path.glob("?emu*.exe"))) > 0
+            return ( len(list(path.glob("?emu*.exe"))) > 0 or len(list(path.glob("?emu"))) > 0 )
         if "game_dir" in params["type"]:
             return (path / "Pack" / "Dungeon000.pack").exists()
         if params["type"] == "update_dir":
@@ -523,8 +523,8 @@ class Api:
             iter(
                 {
                     f
-                    for f in util.get_cemu_dir().glob("*.exe")
-                    if "cemu" in f.name.lower()
+                    for f in util.get_cemu_dir().glob("*")
+                    if ( "cemu" == f.name.lower() ) or ( "cemu" in f.name.lower() and "exe" == f.suffix.lower() )
                 }
             )
         )
@@ -534,7 +534,7 @@ class Api:
         except AssertionError:
             raise FileNotFoundError("Your BOTW executable could not be found")
         cemu_args: List[str]
-        if SYSTEM == "Windows":
+        if (SYSTEM == "Windows") or ( "cemu" == cemu.name.lower() ):
             cemu_args = [str(cemu)]
             if params["run_game"]:
                 cemu_args.extend(("-g", str(uking)))

--- a/bcml/assets/src/js/Settings.jsx
+++ b/bcml/assets/src/js/Settings.jsx
@@ -193,7 +193,7 @@ class Settings extends React.Component {
                                 value={this.state.cemu_dir}
                                 disabled={!this.state.wiiu || this.state.no_cemu}
                                 onChange={this.handleChange}
-                                placeholder='Tip: folder should contain "Cemu.exe"'
+                                placeholder='Tip: folder should contain the Cemu binary/exe'
                                 isValid={
                                     this.state.cemu_dir != "" || this.state.no_cemu
                                 }
@@ -204,7 +204,7 @@ class Settings extends React.Component {
                                                 (Optional) The directory where Cemu is
                                                 installed. Note that this <em>must</em>{" "}
                                                 be the folder that directly contains
-                                                "Cemu.exe" and "settings.xml"
+                                                the Cemu binary/exe and "settings.xml"
                                             </>
                                         ) : (
                                             "Not applicable for Switch mode"


### PR DESCRIPTION
Cemu 2.0 added support for directly running Cemu instead of running from Wine.  This PR changes the settings and the launch button to support(search selected folder for) the Cemu binary as well as Cemu.exe.

Changes are minor, but I have not thoroughly tested, especially on the Windows side.  Please do some basic testing before accepting PR.