### PR TITLE
install.py: Don't try to make rules.txt on export

### DIFF
--- a/bcml/install.py
+++ b/bcml/install.py
@@ -770,27 +770,8 @@ def export(output: Path, standalone: bool = False):
             ) from err
     link_master_mod(tmp_dir)
     print("Adding rules.txt...")
-    rules_path = tmp_dir / "rules.txt"
-    mods = util.get_installed_mods()
-    if util.get_settings("wiiu"):
-        name = "Exported BCML mod" if not standalone else mods[0].name
-        desc = (
-            f'Exported merge of {", ".join([mod.name for mod in mods])}'
-            if not standalone
-            else mods[0].description
-        )
-        while not rules_path.exists():
-            print("Waiting for Python and Windows to figure themselves out...")
-            continue
-        rules_path.write_text(
-            "[Definition]\n"
-            "titleIds = 00050000101C9300,00050000101C9400,00050000101C9500\n"
-            f"name = {name}\n"
-            f"path = The Legend of Zelda: Breath of the Wild/Mods/{name}\n"
-            f"description = {desc}\n"
-            "version = 4\n",
-            encoding="utf-8"
-        )
+    while not (tmp_dir / "content").exists():
+        print("Waiting for Python and Windows to figure themselves out...")
     if output.suffix == ".bnp" or output.name.endswith(".bnp.7z"):
         print("Exporting BNP...")
         dev.create_bnp_mod(

--- a/bcml/mergers/texts.py
+++ b/bcml/mergers/texts.py
@@ -69,18 +69,14 @@ def map_languages(dest_langs: Set[str], src_langs: Set[str]) -> dict:
         if dest_lang in src_langs:
             lang_map[dest_lang] = dest_lang
         else:
-            for src_lang in src_langs:
-                if src_lang[2:4] == dest_lang[2:4]:
-                    lang_map[dest_lang] = src_lang
-                    break
+            for src_lang in [l for l in src_langs if l[2:4] == dest_lang[2:4]]:
+                lang_map[dest_lang] = src_lang
+                break
             if dest_lang in lang_map:
                 continue
-            for src_lang in sorted(
-                src_langs, key=lambda lang: lang[0:2] != dest_lang[0:2]
-            ):
-                if src_lang[2:4] == "en":
-                    lang_map[dest_lang] = src_lang
-                    break
+            for src_lang in [l for l in src_langs if l[2:4] == "en"]:
+                lang_map[dest_lang] = src_lang
+                break
             if dest_lang in lang_map:
                 continue
             lang_map[dest_lang] = next(iter(src_langs))


### PR DESCRIPTION
Previously, if no_cemu was set, `link_master_mod()` would not make rules.txt, which would send the `while` into an infinite loop.

Also, the entire rules_path section was unnecessary, as `link_master_mod()` makes rules.txt if it's needed, already.

Now the `while` checks for the `content` folder, because that will always be there for every mod.