### PR TITLE
Always export to graphicPack directory if using Cemu

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -140,12 +140,12 @@ impl Settings {
     pub fn export_dir(&self) -> Option<PathBuf> {
         if self.wiiu {
             if self.no_cemu {
-                self.export_dir.clone()
+                Some(self.export_dir.clone())
             } else {
                 Some(self.cemu_dir.join("graphicPacks/BreathOfTheWild_BCML"))
             }
         } else {
-            self.export_dir_nx.clone()
+            Some(self.export_dir_nx.clone())
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -138,19 +138,14 @@ impl Settings {
     }
 
     pub fn export_dir(&self) -> Option<PathBuf> {
-        let dir = if self.wiiu {
-            self.export_dir.clone()
-        } else {
-            self.export_dir_nx.clone()
-        };
-        if dir.to_str().map(|d| d.is_empty()).unwrap_or_default() {
-            if self.wiiu && !self.no_cemu {
-                Some(self.cemu_dir.join("graphicPacks/BreathOfTheWild_BCML"))
+        if self.wiiu {
+            if self.no_cemu {
+                self.export_dir.clone()
             } else {
-                None
+                Some(self.cemu_dir.join("graphicPacks/BreathOfTheWild_BCML"))
             }
         } else {
-            Some(dir)
+            self.export_dir_nx.clone()
         }
     }
 


### PR DESCRIPTION
The export_dir setting widget hides itself if the no_cemu setting is false. This PR aligns the behavior with what is expected based on what the UI shows: if no_cemu is false, the export_dir setting will be ignored when merging.