### PR TITLE
ASList merger update

### DIFF
--- a/bcml/mergers/aslist.py
+++ b/bcml/mergers/aslist.py
@@ -1,7 +1,7 @@
 from functools import reduce, partial
 from multiprocessing import Pool
 from pathlib import Path
-from typing import Union, List, ByteString, Optional, Dict, Any
+from typing import Union, List, Set, ByteString, Optional, Dict, Any
 
 from oead.aamp import ParameterIO, ParameterList, ParameterObject, Parameter
 from oead import Sarc, SarcWriter, InvalidDataError, FixedSafeString64
@@ -137,12 +137,12 @@ def merge_plists(
     file_table: bool = False,
 ):
     def merge_addres(plist: ParameterList, other_plist: ParameterList):
-        bfres: List[str] = []
+        bfres: Set[str] = set()
         for _, pobj in plist.objects.items():
-            bfres.append(str(pobj.params["Anim"].v))
+            bfres.add(str(pobj.params["Anim"].v))
         for _, other_pobj in other_plist.objects.items():
-            bfres.append(str(other_pobj.params["Anim"].v))
-        for i, v in enumerate(list(dict.fromkeys(bfres))):
+            bfres.add(str(other_pobj.params["Anim"].v))
+        for i, v in enumerate(bfres):
             key = f"AddRes_{i}"
             if not key in plist.objects:
                 plist.objects[key] = ParameterObject()

--- a/bcml/mergers/aslist.py
+++ b/bcml/mergers/aslist.py
@@ -250,12 +250,12 @@ def merge_plists(
     file_table: bool = False,
 ):
     def merge_addres(plist: ParameterList, other_plist: ParameterList):
-        bfres: Set[str] = set()
+        bfres: Dict[str, Any] = set()
         for _, pobj in plist.objects.items():
-            bfres.add(str(pobj.params["Anim"].v))
+            bfres[str(pobj.params["Anim"].v)] = None
         for _, other_pobj in other_plist.objects.items():
-            bfres.add(str(other_pobj.params["Anim"].v))
-        for i, v in enumerate(bfres):
+            bfres[str(other_pobj.params["Anim"].v)] = None
+        for i, (v, _) in enumerate(bfres):
             key = f"AddRes_{i}"
             if not key in plist.objects:
                 plist.objects[key] = ParameterObject()

--- a/bcml/mergers/aslist.py
+++ b/bcml/mergers/aslist.py
@@ -250,7 +250,7 @@ def merge_plists(
     file_table: bool = False,
 ):
     def merge_addres(plist: ParameterList, other_plist: ParameterList):
-        bfres: Dict[str, Any] = set()
+        bfres: Dict[str, Any] = {}
         for _, pobj in plist.objects.items():
             bfres[str(pobj.params["Anim"].v)] = None
         for _, other_pobj in other_plist.objects.items():
@@ -267,7 +267,7 @@ def merge_plists(
         for i, (_, pobj) in enumerate(plist.objects.items()):
             listing[str(pobj.params["Name"].v)] = i
         for _, other_pobj in other_plist.objects.items():
-            defs[str(other_pobj.params["Name"].v)] = other_pobj.params["Filename"].v
+            defs[str(other_pobj.params["Name"].v)] = str(other_pobj.params["Filename"].v)
         new_idx = len(listing)
         for k, v in defs.items():
             if k in listing:
@@ -277,7 +277,7 @@ def merge_plists(
                 plist.objects[key] = ParameterObject()
                 plist.objects[key].params["Name"] = Parameter(FixedSafeString64(k))
                 new_idx += 1
-            plist.objects[key].params["Filename"] = Parameter(v)
+            plist.objects[key].params["Filename"] = Parameter(FixedSafeString64(v))
     
     def merge_cfdefines(plist: ParameterList, other_plist: ParameterList):
         cfdef_diff = cfdefs_to_dict(other_plist)

--- a/bcml/mergers/shop.py
+++ b/bcml/mergers/shop.py
@@ -99,9 +99,6 @@ def make_shopdata(pio: ParameterIO) -> ParameterList:
     shopdata.objects["TableNames"] = ParameterObject()
     for table in tables:
         table_plist = ParameterList()
-        shopdata.objects["TableNames"].params[table] = Parameter(
-            FixedSafeString64(table)
-        )
         table_hash = crc32(table.encode())
         items: Dict[str, List[int]] = {
             str(p.v): k.hash
@@ -121,10 +118,13 @@ def make_shopdata(pio: ParameterIO) -> ParameterList:
                     item_obj.params[shop_key] = pio.objects[table_hash].params[
                         f"{shop_key}{item_no:03d}"
                     ]
-                except KeyError:
-                    raise KeyError(f"{shop_key}{item_no:03d}")
+                except KeyError as err:
+                    raise KeyError(f"{shop_key}{item_no:03d}") from err
             table_plist.objects[item] = item_obj
         if table_plist.objects:
+            shopdata.objects["TableNames"].params[table] = Parameter(
+                FixedSafeString64(table)
+            )
             shopdata.lists[table_hash] = table_plist
     return shopdata
 


### PR DESCRIPTION
- CFDefine differ/merger, updates each CFDefine's data based on which CFPre is contained inside it
  - Fixes differ logging the entire CFDefines section (works with old logs - will "update" each CFDefine param to the same value it already had)
- ASDefine merger fix x2
  - Leaves existing ASDefine list in place, keeping the references it owns from being destroyed while being owned by another list
  - Copies SafeString contents, instead of the SafeString reference, so underlying data isn't destroyed if the Parameter owning that SafeString gets destroyed (which shouldn't happen because the vanilla ASDefine is no longer destroyed)
- Minor shop merger update: Don't log a table name if the table the corresponding table has no values/doesn't get attached