### PR TITLE
cefpython3 py310+ workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bcml"
 authors = ["Caleb Smith"]
-version = "3.10.4"
+version = "3.10.5"
 edition = "2021"
 readme = "docs/README.md"
 

--- a/bcml/__main__.py
+++ b/bcml/__main__.py
@@ -95,7 +95,7 @@ def main(debug: bool = False):
             del cefpython3
             gui = "cef"
             configure_cef(debug)
-        except ImportError:
+        except (ImportError, Exception):
             from webview.platforms.winforms import _is_chromium
 
             if _is_chromium():

--- a/bcml/__version__.py
+++ b/bcml/__version__.py
@@ -1,6 +1,6 @@
 _MAJOR=3
 _MINOR=10
-_PATCH="4"
+_PATCH="5"
 
 VERSION = f"{_MAJOR}.{_MINOR}.{_PATCH}"
 USER_VERSION = f"""{_MAJOR}.{_MINOR}.{_PATCH[0:1]} {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bcml"
-version = "3.10.4"
+version = "3.10.5"
 description = "A mod manager for The Legend of Zelda: Breath of the Wild"
 author = "NiceneNerd"
 author_email = "macadamiadaze@gmail.com"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("docs/README.md", "r") as readme:
 
 setup(
     name="bcml",
-    version="3.10.4",
+    version="3.10.5",
     author="NiceneNerd",
     author_email="macadamiadaze@gmail.com",
     description="A mod manager for The Legend of Zelda: Breath of the Wild",


### PR DESCRIPTION
Fall back to edgechromium on Windows if cefpython3 throws a bare exception (python version is 3.10+), resolves #491