### PR TITLE
Always skip processing when patch_file is None

### DIFF
--- a/bcml/dev.py
+++ b/bcml/dev.py
@@ -46,7 +46,7 @@ def _package_code(tmp_dir: Path, meta: dict):
         patch_file = tmp_dir / "patches.txt"
     elif list(tmp_dir.glob("patch_*.asm")):
         patch_file = list(tmp_dir.glob("patch_*.asm"))[0]
-    if not patch_file and not (tmp_dir / "patches").exists():
+    if not patch_file:
         return
     (tmp_dir / "patches").mkdir(exist_ok=True)
     shutil.move(patch_file, tmp_dir / "patches" / patch_file.name)


### PR DESCRIPTION
Fixes `AttributeError: 'NoneType' object has no attribute 'name'` when no patch file exists in the root mod directory, but processing still continues because the folder `./patches` exists.

```
Traceback (most recent call last):
  File "c:\users\edgar\appdata\local\programs\python\python38\lib\site-packages\bcml\_api.py", line 33, in status_run
    data = func(*args, **kwargs)
  File "c:\users\edgar\appdata\local\programs\python\python38\lib\site-packages\bcml\_api.py", line 652, in create_bnp
    dev.create_bnp_mod(
  File "c:\users\edgar\appdata\local\programs\python\python38\lib\site-packages\bcml\dev.py", line 374, in create_bnp_mod
    _package_code(tmp_dir, meta)
  File "c:\users\edgar\appdata\local\programs\python\python38\lib\site-packages\bcml\dev.py", line 53, in _package_code
    shutil.move(patch_file, tmp_dir / "patches" / patch_file.name)
AttributeError: 'NoneType' object has no attribute 'name'
```